### PR TITLE
Specify config must be the last one in extends

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ If you don't want the rules to be overridden (If you want to enable only the par
 }
 ```
 
+Since this package configure `customSyntax` option to allow parsing Vue files, be sure it is the **LAST** item into the `extends` array, in case more than one configuration is applied.
+Not complying to this rule may result in broken Vue files parsing, generating confusing errors like `Unknown word (CssSyntaxError)`.
+
 ### With SCSS
 
 Install `stylelint-config-recommended-scss`:


### PR DESCRIPTION
Fixes #19

Since the note is pretty concise, I preferred to avoid creating a new section.
I can change this if you prefer

This should probably replicated on the new `standard` package README too