### PR TITLE
Add installation of postcss-scss to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Not complying to this rule may result in broken Vue files parsing, generating co
 
 ### With SCSS
 
-Install `stylelint-config-recommended-scss`:
+Install `postcss-scss` and `stylelint-config-recommended-scss`:
 
 ```shell
-npm install --save-dev stylelint-config-recommended-scss
+npm install --save-dev postcss-scss stylelint-config-recommended-scss
 ```
 
 Set your `stylelint` config to:


### PR DESCRIPTION
When `postcss-scss` is not installed and one uses the `scss` config, the result will be silent skipping of all scss blocks as they cannot be parsed. This results in linting always succeeding for all such files, which is unwanted.

I'm not sure if there's some way to raise a more appropriate warning for such cases, but I think adding an explicit installation note to the `README` might be a good start.