### PR TITLE
Update stylelint-config-recommended to v15 to support Stylelint v16.13.

### DIFF
--- a/.changeset/fair-fans-dress.md
+++ b/.changeset/fair-fans-dress.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-recommended-vue": minor
+---
+
+Update stylelint-config-recommended to v15 to support Stylelint v16.13.

--- a/lib/vue-specific-rules.js
+++ b/lib/vue-specific-rules.js
@@ -17,6 +17,16 @@ module.exports = {
       ignorePseudoElements: ["v-deep", "v-global", "v-slotted"],
     },
   ],
+  ...(semver.gte(stylelintVersion, "16.13.0")
+    ? {
+        "declaration-property-value-no-unknown": [
+          true,
+          {
+            ignoreProperties: { "/.*/": "/v-bind\\(.+\\)/" },
+          },
+        ],
+      }
+    : {}),
   ...(semver.gte(stylelintVersion, "14.5.0")
     ? {
         "function-no-unknown": [true, { ignoreFunctions: ["v-bind"] }],

--- a/tests/fixtures/integrations/stylelint-v16/package.json
+++ b/tests/fixtures/integrations/stylelint-v16/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^16.0.0",
-    "stylelint-config-recommended": "^14.0.0",
+    "stylelint-config-recommended": "^15.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },
   "engines": {


### PR DESCRIPTION
First of all, thank you to the maintainers for keeping this wonderful repository. 
This is my first PR, and I hope it will be helpful.

### Why

fixed https://github.com/ota-meshi/stylelint-config-recommended-vue/issues/82

### Description

In Stylelint v16.13, the `declaration-property-value-no-unknown` rule has been changed to generate the following error when setting properties using `v-bind`:

```
3:12 ✖ Unexpected unknown value for property “color” declaration-property-value-no-unknown “v-bind(color)”
```

The `declaration-property-value-no-unknown` rule is enabled in `stylelint-config-recommended` v15.

To avoid errors when specifying properties using `v-bind` in Stylelint v16.13 and later, I updated the fixture's package.json to use stylelint-config-recommended v15 and added `ignoreProperties` to `vue-specific-rules.js`.

[FYI]

* https://stylelint.io/user-guide/rules/declaration-property-value-no-unknown/
* https://github.com/stylelint/stylelint-config-recommended/releases/tag/15.0.0