### PR TITLE
Fix `declaration-property-value-no-unknown` rule for SCSS in Vue files

### DIFF
--- a/lib/vue-specific-rules-for-scss.js
+++ b/lib/vue-specific-rules-for-scss.js
@@ -5,4 +5,5 @@ const baseRules = require("./vue-specific-rules");
 module.exports = {
   ...baseRules,
   ...(baseRules["function-no-unknown"] ? { "function-no-unknown": null } : {}),
+  "declaration-property-value-no-unknown": null,
 };


### PR DESCRIPTION
Fixes #86

Disable the `declaration-property-value-no-unknown` rule for CSS-like languages such as SCSS in Vue files.

* Modify `lib/vue-specific-rules-for-scss.js` to disable the `declaration-property-value-no-unknown` rule by setting it to `null`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ota-meshi/stylelint-config-recommended-vue/pull/87?shareId=799a6210-0b41-4da5-9fc7-43a425301cb7).