### PR TITLE
Use npm Trusted Publishing

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -5,35 +5,37 @@ on:
     branches:
       - main
 
+permissions: {}
+
+# Allow one concurrent deployment
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
+    # prevents this action from running on forks
+    if: github.repository == 'ota-meshi/stylelint-config-recommended-vue'
+    permissions:
+      contents: write # to create release (changesets/action)
+      id-token: write # OpenID Connect token needed for provenance
+      pull-requests: write # to create pull request (changesets/action)
     name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
         with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
-
-      - name: Setup Node.js 16
-        uses: actions/setup-node@v6
-        with:
-          node-version: 16
-
+          node-version: lts/*
       - name: Install Dependencies
-        run: npm install -f
-
+        run: npm i -f
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
-          # this expects you to have a npm script called version that runs some logic and then calls `changeset version`.
-          version: npm run version:ci
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: npm run release
-          commit: "chore: release stylelint-config-recommended-vue"
-          title: "chore: release stylelint-config-recommended-vue"
+          version: npm run changeset:version
+          publish: npm run changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
     "test": "mocha \"tests/lib/**/*.js\" --reporter dot --timeout 60000",
     "lint": "eslint .",
     "eslint-fix": "eslint . --fix",
-    "version": "npm run test && git add .",
-    "version:ci": "changeset version",
-    "release": "changeset publish"
+    "changeset:version": "changeset version",
+    "changeset:publish": "changeset publish"
   },
   "dependencies": {
     "semver": "^7.3.5",


### PR DESCRIPTION
This switches the `Release.yml` workflow to authenticate with npm via OIDC (npm Trusted Publishing) instead of the `NPM_TOKEN` secret, matching the setup in ota-meshi/stylelint-config-html. The workflow now runs with least-privilege permissions (plus `id-token: write` for provenance), is guarded against running on forks, and uses the latest actions with Node.js LTS so that the bundled npm supports OIDC publishing.

The `version`/`version:ci`/`release` scripts are consolidated into `changeset:version`/`changeset:publish` to match the workflow inputs, and the custom release PR title is dropped in favor of the changesets default.

Before the next release, the package needs a Trusted Publisher configured on npmjs.com (GitHub Actions, repository `ota-meshi/stylelint-config-recommended-vue`, workflow `Release.yml`); the `NPM_TOKEN` secret can be removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)