### PR TITLE
Set changesets access to public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   ],
   "commit": false,
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "bumpVersionsWithWorkspaceProtocolOnly": true,


### PR DESCRIPTION
`.changeset/config.json` had `"access": "restricted"`, the same setting that broke the stylelint-config-html v2.0.0 release with `EUNSCOPED Can't restrict access to unscoped packages` (ota-meshi/stylelint-config-html#71).

In this repository the failure would not actually occur, because `changeset publish` resolves access as `publishConfig.access || config.access` and package.json already declares `"publishConfig": { "access": "public" }`. Still, the restricted value is misleading and would break publishing if `publishConfig` were ever removed, so this aligns the config with stylelint-config-html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)