### PR TITLE
Restrict stylelint-config-html dependency to v1

### DIFF
--- a/.changeset/restrict-stylelint-config-html-v1.md
+++ b/.changeset/restrict-stylelint-config-html-v1.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-recommended-vue": patch
+---
+
+Restrict the `stylelint-config-html` dependency to v1. stylelint-config-html v2 is ESM-only and requires Stylelint v16+ and Node.js v22.12+, so installs on the older environments this config still supports were broken.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "semver": "^7.3.5",
-    "stylelint-config-html": ">=1.0.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended": ">=6.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
CI started failing on every PR after stylelint-config-html v2.0.0 was released: the `stylelint-config-html: ">=1.0.0"` dependency range now resolves to v2, which is ESM-only and requires Stylelint v16+ and Node.js v22.12+. The integration fixtures for older Stylelint/Node versions fail with `ERR_REQUIRE_ESM`, and fresh installs by end users on those environments would break the same way.

This restricts the dependency to `^1.0.0`, which still works with Stylelint v14–v17. Moving to stylelint-config-html v2 can happen in a future major together with dropping old Stylelint/Node support. A changeset (patch) is included so the fix gets released.

Verified locally by deleting the fixtures' `node_modules` and re-running the tests: all fixtures resolve stylelint-config-html v1.1.0 and all 20 tests pass.

The CI failure on #116 has this same root cause; re-running its checks after this lands should turn it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)