### PR TITLE
Pin stylelint-config-html to v1 in integration fixtures

### DIFF
--- a/tests/fixtures/integrations/function-no-unknown/package.json
+++ b/tests/fixtures/integrations/function-no-unknown/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^14.5.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended": "^7.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/fixtures/integrations/stylelint-config-standard-scss/package.json
+++ b/tests/fixtures/integrations/stylelint-config-standard-scss/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^14.0.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended-scss": "^5.0.2",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz",
     "stylelint-config-standard-scss": "^3.0.0"

--- a/tests/fixtures/integrations/stylelint-scss-v4.1/package.json
+++ b/tests/fixtures/integrations/stylelint-scss-v4.1/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^14.0.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended-scss": "^5.0.2",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz",
     "stylelint-scss": "4.1.0"

--- a/tests/fixtures/integrations/stylelint-scss/package.json
+++ b/tests/fixtures/integrations/stylelint-scss/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^14.0.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended-scss": "^6.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/fixtures/integrations/stylelint-v14.3/package.json
+++ b/tests/fixtures/integrations/stylelint-v14.3/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "14.3.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended": "^6.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/fixtures/integrations/stylelint-v14.4/package.json
+++ b/tests/fixtures/integrations/stylelint-v14.4/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "14.4.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended": "^7.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/fixtures/integrations/stylelint-v14/package.json
+++ b/tests/fixtures/integrations/stylelint-v14/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^14.5.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended": "^7.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/fixtures/integrations/stylelint-v15/package.json
+++ b/tests/fixtures/integrations/stylelint-v15/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^15.10.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended": "^13.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/fixtures/integrations/stylelint-v16-scss/package.json
+++ b/tests/fixtures/integrations/stylelint-v16-scss/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^16.0.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/fixtures/integrations/stylelint-v16/package.json
+++ b/tests/fixtures/integrations/stylelint-v16/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "postcss-html": "^1.0.0",
     "stylelint": "^16.0.0",
+    "stylelint-config-html": "^1.0.0",
     "stylelint-config-recommended": "^15.0.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -44,11 +44,12 @@ for (const entry of fs.readdirSync(FIXTURES_ROOT_DIR, {
     before(() => {
       originalCwd = process.cwd();
       process.chdir(fixtureDir);
-      cp.execSync(`npm i ${tgzName}`, { stdio: "inherit" });
-      cp.execSync(
-        "npx -y rimraf ./node_modules/stylelint-config-recommended-vue",
-        { stdio: "inherit" },
-      );
+      // Install from an empty node_modules in a single `npm i` run.
+      // A stepwise install can leave a hoisted stylelint-config-html that
+      // does not match the fixture's pinned version, because old npm (v6)
+      // demotes the mismatched copy under stylelint-config-recommended-vue
+      // instead of removing it.
+      cp.execSync("npx -y rimraf ./node_modules", { stdio: "inherit" });
       cp.execSync("npm i", { stdio: "inherit" });
     });
     after(() => {

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -49,7 +49,9 @@ for (const entry of fs.readdirSync(FIXTURES_ROOT_DIR, {
       // does not match the fixture's pinned version, because old npm (v6)
       // demotes the mismatched copy under stylelint-config-recommended-vue
       // instead of removing it.
-      cp.execSync("npx -y rimraf ./node_modules", { stdio: "inherit" });
+      if (fs.existsSync("./node_modules")) {
+        cp.execSync("npx -y rimraf ./node_modules", { stdio: "inherit" });
+      }
       cp.execSync("npm i", { stdio: "inherit" });
     });
     after(() => {


### PR DESCRIPTION
CI has been failing on every PR since stylelint-config-html v2.0.0 was released: the fixtures' fresh installs resolve the `stylelint-config-html: ">=1.0.0"` dependency to v2, which is ESM-only and requires Stylelint v16+ and Node.js v22.12+, so the fixtures covering older Stylelint/Node versions fail with `ERR_REQUIRE_ESM`. The package's own dependency range is left unchanged; only the test setup changes.

Two changes are needed to make the fixtures resolve v1:

- Each fixture's devDependencies pin `stylelint-config-html` to `^1.0.0`, matching the Stylelint v14–v16 / postcss-html v1 combinations the fixtures cover.
- The test harness now installs each fixture from an empty `node_modules` in a single `npm i` run instead of `npm i <tgz>` → rimraf → `npm i`. With the stepwise install, npm 6 (Node 12/14) first hoists v2 from the tarball's `>=1.0.0` range, and on the second run demotes that copy under `stylelint-config-recommended-vue` instead of removing it, so the pin never takes effect. From an empty tree, all npm versions dedupe onto the fixture's pinned v1.

Verified locally with fresh installs: all fixtures resolve stylelint-config-html v1.1.0 with no nested copy, and all 20 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)