### PR TITLE
Drop support for old Node.js versions

### DIFF
--- a/.changeset/drop-old-node.md
+++ b/.changeset/drop-old-node.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-recommended-vue": major
+---
+
+Drop support for old Node.js versions. Node.js `^22.12 || >=24` is now required.

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
       - name: Install Packages
         run: npm i -f
       - name: Lint
@@ -20,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [22.x, 24.x]
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -37,7 +39,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 14.x
+          node-version: lts/*
       - name: Downgrade Packages
         run: |
           npm install --save-exact stylelint@14.0.0 stylelint-config-recommended@6.0.0 -f

--- a/.github/workflows/NodeCI.yml
+++ b/.github/workflows/NodeCI.yml
@@ -33,18 +33,3 @@ jobs:
         run: npm i -f
       - name: Test
         run: npm test
-  test-old-vers:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: lts/*
-      - name: Downgrade Packages
-        run: |
-          npm install --save-exact stylelint@14.0.0 stylelint-config-recommended@6.0.0 -f
-          npx rimraf node_modules
-      - name: Install Packages
-        run: npm i -f
-      - name: Test
-        run: npm test

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This config:
 >
 > - [Stylelint] v14.0.0 and above  
 >   It cannot be used with Stylelint v13 and below.
+> - Node.js `^22.12 || >=24`
 
 To see the rules that this config uses, please read the [config itself](/lib/index.js).
 

--- a/lib/get-module-version.js
+++ b/lib/get-module-version.js
@@ -16,7 +16,6 @@ module.exports = function getModuleVersion(...moduleNames) {
   try {
     const m = require("module");
     const relativeTo = path.join(ownerModuleRootPath, "__placeholder__.js");
-    // eslint-disable-next-line n/no-unsupported-features/node-builtins -- ignore
     return m.createRequire(relativeTo)(`${packageName}/package.json`).version;
   } catch {
     // ignore
@@ -39,7 +38,6 @@ function getModuleRootPath(packageName, ownerModuleRootPath) {
     const relativeTo = path.join(ownerModuleRootPath, "__placeholder__.js");
 
     return path.dirname(
-      // eslint-disable-next-line n/no-unsupported-features/node-builtins -- ignore
       m.createRequire(relativeTo).resolve(`${packageName}/package.json`),
     );
   } catch {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scss"
   ],
   "engines": {
-    "node": "^12 || >=14"
+    "node": "^22.12 || >=24"
   },
   "scripts": {
     "test": "mocha \"tests/lib/**/*.js\" --reporter dot --timeout 60000",


### PR DESCRIPTION
This drops support for old Node.js versions, requiring Node.js `^22.12 || >=24`, in line with ota-meshi/stylelint-config-html v2. It is the first of the planned breaking changes for the next major release, ahead of requiring Stylelint v16+/postcss-html v2, moving stylelint-config-recommended to peerDependencies (#68), and migrating to ESM.

The CI test matrix moves from Node.js 12–18 to 22/24, and jobs that do not depend on a specific Node.js version now use `lts/*`. The `n/no-unsupported-features` eslint-disable comments for `module.createRequire` were removed since the API is supported across the new range. A major changeset is included.

The `test-old-vers` job is removed: it pins the package's dependencies to stylelint@14.0.0 / stylelint-config-recommended@6.0.0, which only worked while Node.js 14 excluded the stylelint-v16 fixtures — on newer Node.js those fixtures run too, and Stylelint v16 rejects the v6 config (`Unknown rule no-extra-semicolons`, removed in v16). The regular test job still covers Stylelint 14.3–16 through the fixtures until the Stylelint v16+ requirement lands in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)