### PR TITLE
Move stylelint-config-recommended to peerDependencies

### DIFF
--- a/.changeset/move-config-recommended-to-peer.md
+++ b/.changeset/move-config-recommended-to-peer.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-recommended-vue": major
+---
+
+Move `stylelint-config-recommended` and `stylelint-config-html` from dependencies to peer dependencies, so that their versions are controlled by your project instead of always resolving to the latest release ([#68](https://github.com/ota-meshi/stylelint-config-recommended-vue/issues/68)). npm v7+ installs peer dependencies automatically; with other package managers you may need to install them yourself. The `stylelint-config-recommended-scss` config used by the `/scss` entry is now declared as an optional peer dependency.

--- a/.changeset/move-config-recommended-to-peer.md
+++ b/.changeset/move-config-recommended-to-peer.md
@@ -2,4 +2,4 @@
 "stylelint-config-recommended-vue": major
 ---
 
-Move `stylelint-config-recommended` and `stylelint-config-html` from dependencies to peer dependencies, so that their versions are controlled by your project instead of always resolving to the latest release ([#68](https://github.com/ota-meshi/stylelint-config-recommended-vue/issues/68)). npm v7+ installs peer dependencies automatically; with other package managers you may need to install them yourself. The `stylelint-config-recommended-scss` config used by the `/scss` entry is now declared as an optional peer dependency.
+Move `stylelint-config-recommended` and `stylelint-config-html` from dependencies to peer dependencies, so that their versions are controlled by your project instead of always resolving to the latest release ([#68](https://github.com/ota-meshi/stylelint-config-recommended-vue/issues/68)). The `stylelint-config-recommended-scss` config used by the `/scss` entry is now declared as an optional peer dependency.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ To see the rules that this config uses, please read the [config itself](/lib/ind
 ## :cd: Installation
 
 ```shell
-npm install --save-dev postcss-html stylelint-config-recommended-vue
+npm install --save-dev postcss-html stylelint-config-html stylelint-config-recommended stylelint-config-recommended-vue
 ```
+
+`stylelint-config-html` and `stylelint-config-recommended` are peer dependencies. npm v7+ installs peer dependencies automatically, but with other package managers you may need to install them yourself.
 
 ## :book: Usage
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ To see the rules that this config uses, please read the [config itself](/lib/ind
 npm install --save-dev postcss-html stylelint-config-html stylelint-config-recommended stylelint-config-recommended-vue
 ```
 
+The shared configs that this config extends (`stylelint-config-html` and `stylelint-config-recommended`) are peer dependencies, so you can control their versions from your own `package.json`.
+
 ## :book: Usage
 
 Set your `stylelint` config to:

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ To see the rules that this config uses, please read the [config itself](/lib/ind
 npm install --save-dev postcss-html stylelint-config-html stylelint-config-recommended stylelint-config-recommended-vue
 ```
 
-`stylelint-config-html` and `stylelint-config-recommended` are peer dependencies. npm v7+ installs peer dependencies automatically, but with other package managers you may need to install them yourself.
-
 ## :book: Usage
 
 Set your `stylelint` config to:

--- a/package.json
+++ b/package.json
@@ -24,13 +24,19 @@
     "changeset:publish": "changeset publish"
   },
   "dependencies": {
-    "semver": "^7.3.5",
-    "stylelint-config-html": ">=2.0.0",
-    "stylelint-config-recommended": ">=6.0.0"
+    "semver": "^7.3.5"
   },
   "peerDependencies": {
     "postcss-html": "^2.0.0",
-    "stylelint": ">=16.0.0"
+    "stylelint": ">=16.0.0",
+    "stylelint-config-html": ">=2.0.0",
+    "stylelint-config-recommended": ">=14.0.0",
+    "stylelint-config-recommended-scss": ">=14.0.0"
+  },
+  "peerDependenciesMeta": {
+    "stylelint-config-recommended-scss": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/tests/fixtures/integrations/stylelint-v16-scss/package.json
+++ b/tests/fixtures/integrations/stylelint-v16-scss/package.json
@@ -7,6 +7,7 @@
     "postcss-html": "^2.0.0",
     "stylelint": "^16.0.0",
     "stylelint-config-html": "^2.0.0",
+    "stylelint-config-recommended": "^15.0.0",
     "stylelint-config-recommended-scss": "^14.1.0",
     "stylelint-config-recommended-vue": "file:../../../../stylelint-config-recommended-vue-test.tgz"
   },


### PR DESCRIPTION
This moves `stylelint-config-recommended` from dependencies to peerDependencies, so its version is controlled by the user's project instead of always resolving to the latest release, which breaks installs on environments the latest release no longer supports.

`stylelint-config-html` moves to peerDependencies as well, for the same reason: its `>=` dependency range resolving to a new major is exactly what recently broke CI (and fresh user installs) when stylelint-config-html v2.0.0 was published. `stylelint-config-recommended-scss`, which the `/scss` entry extends but was previously undeclared, is now an optional peer dependency, so its version is validated when it is installed.

The README installation command now includes the peer configs. The stylelint-v16-scss fixture declares `stylelint-config-recommended@^15.0.0` explicitly because the peer range would otherwise resolve to v18, which requires Stylelint v17. A major changeset is included.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)