### PR TITLE
Migrate to ESM

### DIFF
--- a/.changeset/migrate-to-esm.md
+++ b/.changeset/migrate-to-esm.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-recommended-vue": major
+---
+
+Migrate the package to ESM. On the supported Node.js versions, the configs can still be loaded from CommonJS via `require()`. The package now also defines an `exports` field; the `/scss` deep import keeps working both with and without the `/index.js` suffix.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,6 @@
-"use strict";
+import otaMeshi from "@ota-meshi/eslint-plugin";
 
-const otaMeshi = require("@ota-meshi/eslint-plugin");
-
-module.exports = [
+export default [
   {
     ignores: [
       ".nyc_output/**",
@@ -21,8 +19,21 @@ module.exports = [
   }),
   {
     languageOptions: {
+      sourceType: "module",
+      ecmaVersion: "latest",
+    },
+  },
+  {
+    // CommonJS files, including the fixtures that emulate CommonJS consumers.
+    files: ["**/*.cjs", "tests/fixtures/**/*.js"],
+    languageOptions: {
       sourceType: "commonjs",
-      ecmaVersion: 2020,
+      globals: {
+        __dirname: "readonly",
+        exports: "writable",
+        module: "readonly",
+        require: "readonly",
+      },
     },
   },
 ];

--- a/lib/get-module-version.js
+++ b/lib/get-module-version.js
@@ -1,11 +1,12 @@
-"use strict";
+import { createRequire } from "node:module";
+import path from "node:path";
 
-const path = require("path");
+const require = createRequire(import.meta.url);
 
 /**
  * Gets the module version from package name
  */
-module.exports = function getModuleVersion(...moduleNames) {
+export default function getModuleVersion(...moduleNames) {
   const packageName = moduleNames.pop();
 
   let ownerModuleRootPath = process.cwd();
@@ -14,9 +15,8 @@ module.exports = function getModuleVersion(...moduleNames) {
       getModuleRootPath(ownerNames, ownerModuleRootPath) || ownerModuleRootPath;
   }
   try {
-    const m = require("module");
     const relativeTo = path.join(ownerModuleRootPath, "__placeholder__.js");
-    return m.createRequire(relativeTo)(`${packageName}/package.json`).version;
+    return createRequire(relativeTo)(`${packageName}/package.json`).version;
   } catch {
     // ignore
   }
@@ -27,18 +27,17 @@ module.exports = function getModuleVersion(...moduleNames) {
   }
 
   return null;
-};
+}
 
 /**
  * Get module root path
  */
 function getModuleRootPath(packageName, ownerModuleRootPath) {
   try {
-    const m = require("module");
     const relativeTo = path.join(ownerModuleRootPath, "__placeholder__.js");
 
     return path.dirname(
-      m.createRequire(relativeTo).resolve(`${packageName}/package.json`),
+      createRequire(relativeTo).resolve(`${packageName}/package.json`),
     );
   } catch {
     // ignore

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,14 @@
-"use strict";
+import vueSpecificRules from "./vue-specific-rules.js";
 
-module.exports = {
+const config = {
   overrides: [
     {
       files: ["*.vue", "**/*.vue"],
       extends: ["stylelint-config-recommended", "stylelint-config-html"],
-      rules: require("./vue-specific-rules"),
+      rules: vueSpecificRules,
     },
   ],
 };
+
+export default config;
+export { config as "module.exports" };

--- a/lib/vue-specific-rules-for-scss.js
+++ b/lib/vue-specific-rules-for-scss.js
@@ -1,11 +1,11 @@
-"use strict";
+import baseRules from "./vue-specific-rules.js";
 
-const baseRules = require("./vue-specific-rules");
-
-module.exports = {
+const rules = {
   ...baseRules,
   ...(baseRules["function-no-unknown"] ? { "function-no-unknown": null } : {}),
   ...(baseRules["declaration-property-value-no-unknown"]
     ? { "declaration-property-value-no-unknown": null }
     : {}),
 };
+
+export default rules;

--- a/lib/vue-specific-rules.js
+++ b/lib/vue-specific-rules.js
@@ -1,10 +1,9 @@
-"use strict";
+import semver from "semver";
+import getModuleVersion from "./get-module-version.js";
 
-const getModuleVersion = require("./get-module-version");
-const semver = require("semver");
 const stylelintVersion = getModuleVersion("stylelint") || "16.0.0";
 
-module.exports = {
+const rules = {
   "selector-pseudo-class-no-unknown": [
     true,
     {
@@ -29,3 +28,5 @@ module.exports = {
     : {}),
   "function-no-unknown": [true, { ignoreFunctions: ["v-bind"] }],
 };
+
+export default rules;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,15 @@
     "recommended",
     "vue"
   ],
+  "type": "module",
   "main": "lib/index.js",
+  "exports": {
+    ".": "./lib/index.js",
+    "./lib/index.js": "./lib/index.js",
+    "./scss": "./scss/index.js",
+    "./scss/index.js": "./scss/index.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "lib",
     "scss"

--- a/scss/index.js
+++ b/scss/index.js
@@ -1,11 +1,14 @@
-"use strict";
+import vueSpecificRulesForScss from "../lib/vue-specific-rules-for-scss.js";
 
-module.exports = {
+const config = {
   overrides: [
     {
       files: ["*.vue", "**/*.vue"],
       extends: ["stylelint-config-recommended-scss", "stylelint-config-html"],
-      rules: require("../lib/vue-specific-rules-for-scss"),
+      rules: vueSpecificRulesForScss,
     },
   ],
 };
+
+export default config;
+export { config as "module.exports" };

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1,10 +1,12 @@
-"use strict";
+import { fail } from "node:assert";
+import cp from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import semver from "semver";
 
-const { fail } = require("assert");
-const cp = require("child_process");
-const path = require("path");
-const fs = require("fs");
-const semver = require("semver");
+const require = createRequire(import.meta.url);
 
 cp.execSync("npm pack", { stdio: "inherit" });
 const orgTgzName = path.resolve(
@@ -20,7 +22,9 @@ fs.renameSync(orgTgzName, tgzName);
 
 const STYLELINT = `.${path.sep}node_modules${path.sep}.bin${path.sep}stylelint`;
 
-const FIXTURES_ROOT_DIR = path.join(__dirname, "../fixtures/integrations");
+const FIXTURES_ROOT_DIR = fileURLToPath(
+  new URL("../fixtures/integrations", import.meta.url),
+);
 for (const entry of fs.readdirSync(FIXTURES_ROOT_DIR, {
   withFileTypes: true,
 })) {


### PR DESCRIPTION
This migrates the package to ESM, in line with ota-meshi/stylelint-config-html v2 — the last of the planned breaking changes for the next major release, following #120, #123, and #124.

The configs export a `"module.exports"` named export alongside the default export, so on the supported Node.js versions they can still be loaded from CommonJS via `require()` — verified by the integration fixtures, whose `stylelint.config.js` files remain CommonJS. The package now defines an `exports` field: the `.` and `/scss` entries keep working with and without the file path (`/lib/index.js`, `/scss/index.js`), and other internals are no longer importable.

`lib/get-module-version.js` keeps its behavior via `createRequire`, and the test suite and eslint.config.js move to ESM as well, with a lint override keeping the fixtures parsed as CommonJS. A major changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)