### PR TITLE
Update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,17 @@
 {
-  "extends": [
-    "config:base",
-    ":preserveSemverRanges",
-    ":disableDependencyDashboard"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":preserveSemverRanges"],
   "packageRules": [
     {
-      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     },
     {
-      "depTypeList": ["devDependencies"],
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions", "devcontainer"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
This aligns renovate.json with ota-meshi/stylelint-config-html: `config:base` becomes `config:recommended`, the legacy `updateTypes`/`depTypeList` fields become `matchUpdateTypes`/`matchDepTypes`, and a `$schema` reference is added. Updates from the github-actions and devcontainer managers are now automerged, and `:disableDependencyDashboard` is dropped, so the dependency dashboard issue will appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)