### PR TITLE
Fix README wording about postcss-html

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 This config:
 
 - extends the [`stylelint-config-recommended` shared config](https://github.com/stylelint/stylelint-config-recommended) and configures its rules for Vue
-- bundles the [`postcss-html` custom syntax](https://github.com/ota-meshi/postcss-html) and configures it
+- configures the [`postcss-html` custom syntax](https://github.com/ota-meshi/postcss-html) via [`stylelint-config-html`](https://github.com/ota-meshi/stylelint-config-html)
 
 > **Requirements**
 >


### PR DESCRIPTION
The intro said this config "bundles" the postcss-html custom syntax, which is no longer accurate now that postcss-html is a peer dependency installed by the consumer. It now says the config configures the custom syntax via stylelint-config-html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)