### PR TITLE
Update changesets setup

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": [
     "@changesets/changelog-github",
     {
@@ -7,10 +7,10 @@
     }
   ],
   "commit": false,
+  "fixed": [],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": []
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.24.2",
+    "@changesets/cli": "^2.31.1",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
     "@ota-meshi/eslint-plugin": "^0.20.0",
     "eslint": "^10.0.0",


### PR DESCRIPTION
This aligns the changesets setup with ota-meshi/stylelint-config-html: the `$schema` reference in `.changeset/config.json` is pinned to `@changesets/config@3.1.4`, the `fixed` option is declared explicitly, the workspace-only `bumpVersionsWithWorkspaceProtocolOnly` option is dropped, and the `@changesets/cli` range moves to `^2.31.1` (the version already resolved by the previous caret range). No behavior changes; `changeset status` reports the pending major as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)