### PR TITLE
Fix Changesets action inputs

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -35,7 +35,7 @@ jobs:
         id: changesets
         uses: changesets/action@v2.0.0
         with:
-          version: npm run changeset:version
-          publish: npm run changeset:publish
+          version-script: npm run changeset:version
+          publish-script: npm run changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changesets Action v2 renamed the version and publish inputs. The release workflow still used the v1 names, so main-branch release runs stopped before creating the version pull request or publishing.

This updates the workflow to use `version-script` and `publish-script` while preserving the existing commands.
